### PR TITLE
Add maxBuffer: Infinity to mix command in order to avoid 'stdout maxBuffer length exceeded' on big projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the vscode-elixir-test-explorer extension will be documented in this file.
 
+## v0.5.0 - 19 September 2022
+
+- Elixir 1.14.0 support #21
+
 ## v0.4.0 - 25 May 2022
 
 - Fix a bug introduced in v0.3.0 #18

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "images/icon.png",
   "author": "Adam Zapaśnik <contact@adamzapasnik.io>",
   "publisher": "adamzapasnik",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "engines": {
     "vscode": "^1.52.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "images/icon.png",
   "author": "Adam Zapaśnik <contact@adamzapasnik.io>",
   "publisher": "adamzapasnik",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "engines": {
     "vscode": "^1.52.0"
   },

--- a/src/MixRunner.ts
+++ b/src/MixRunner.ts
@@ -14,7 +14,7 @@ export class MixRunner {
     return new Promise<string>((resolve, reject) => {
       const command = `mix test --trace --seed=0 --only="*"`;
 
-      this.currentProcess = childProcess.exec(command, { cwd: mixPath }, (err, stdout, stderr) => {
+      this.currentProcess = childProcess.exec(command, { cwd: mixPath, maxBuffer: Infinity }, (err, stdout, stderr) => {
         if (stderr.trim() === 'The --only option was given to "mix test" but no test was executed') {
           return resolve(stdout);
         } else if (stdout.trim().includes('== Compilation error in file')) {
@@ -33,7 +33,7 @@ export class MixRunner {
     return new Promise<string>((resolve, reject) => {
       const command = `mix test ${filePath}`;
 
-      this.currentProcess = childProcess.exec(command, { cwd: mixPath }, (_, stdout, stderr) => {
+      this.currentProcess = childProcess.exec(command, { cwd: mixPath, maxBuffer: Infinity }, (_, stdout, stderr) => {
         if (stdout.includes('Paths given to "mix test" did not match any directory/file')) {
           return reject(`Failed to run tests in project ${mixPath}:\n ${stdout}`);
         }

--- a/src/utils/tests_parsers.ts
+++ b/src/utils/tests_parsers.ts
@@ -21,6 +21,7 @@ export function parseMixOutput(projectDir: string, stdout: string): Map<string, 
 
   const tests = cleanOutput
     .trim()
+    .replace(/All tests have been excluded./g, "") // Remove the line "All tests have been excluded." introduced by elixir 1.14.0
     .split('\n\n') // tests grouped per files
     .map((string) => string.split('\n').filter((string) => string)) // sometimes there are no tests, like an empty doctest
     .filter((arr) => arr.length > 1) // Some files don't have tests


### PR DESCRIPTION
Might be better to make this setting configurable, but I know next to nothing about VSCode extension development and currently not able to commit time to figuring that out.